### PR TITLE
Add Travis CI 

### DIFF
--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,2 @@
+language: dart
+with_content_shell: true


### PR DESCRIPTION
Let's add a CI test runner. I've added a travis.yml file and configured the service to run when a pull request is created. The `with_content_shell` parameter ensures the test runner is run a headless browser which will allow tests to do DOM manipulations in the future.