### PR TITLE
Message Type Marshalling

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -1,1 +1,1 @@
-export "package:client/src/transport_client.dart";
+export "package:client/src/transports/transport_client.dart";

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -1,1 +1,1 @@
-export "package:client/src/client/transport_client.dart";
+export "package:client/src/transport_client.dart";

--- a/lib/src/agent.dart
+++ b/lib/src/agent.dart
@@ -1,3 +1,5 @@
+library client.src.agent;
+
 class Agent {
   String name;
   String status;

--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -1,6 +1,8 @@
-import 'package:client/src/client/messages/message.dart';
-import 'package:client/src/client/agent.dart';
-import 'package:client/src/client/file_factory.dart';
+library client.src.channel;
+
+import 'package:client/src/messages/message.dart';
+import 'package:client/src/agent.dart';
+import 'package:client/src/file_factory.dart';
 
 abstract class Channel {
   List<Message> _messages = new List<Message>();

--- a/lib/src/file_factory.dart
+++ b/lib/src/file_factory.dart
@@ -1,8 +1,8 @@
-library client.src.client.file_factory;
+library client.src.file_factory;
 
 import 'dart:async';
 
-import 'package:client/src/client/messages/file.dart';
+import 'package:client/src/messages/file.dart';
 
 class FileFactory {
   Future<File> createFile() async {

--- a/lib/src/messages/file.dart
+++ b/lib/src/messages/file.dart
@@ -1,4 +1,6 @@
-import 'package:client/src/client/messages/message.dart';
+library client.src.messages.file;
+
+import 'package:client/src/messages/message.dart';
 
 class File extends Message {
   String title;

--- a/lib/src/messages/file.dart
+++ b/lib/src/messages/file.dart
@@ -7,12 +7,17 @@ class File extends Message {
 
   File({this.title});
 
+  @override
   void render() {
     // TODO: implement render
   }
+
+  @override
+  Map marshal() => {'title': title};
 }
 
 class Image extends File {
+  @override
   void render() {
     // TODO: An image will render in line
   }

--- a/lib/src/messages/link.dart
+++ b/lib/src/messages/link.dart
@@ -1,4 +1,6 @@
-import 'package:client/src/client/messages/message.dart';
+library client.src.messages.link;
+
+import 'package:client/src/messages/message.dart';
 
 class Link extends Message {
   String title;

--- a/lib/src/messages/markdown.dart
+++ b/lib/src/messages/markdown.dart
@@ -1,4 +1,6 @@
-import 'package:client/src/client/messages/message.dart';
+library client.src.messages.markdown;
+
+import 'package:client/src/messages/message.dart';
 
 class MarkdownMessage extends Message {
   final List<Message> _children = new List<Message>();

--- a/lib/src/messages/markdown.dart
+++ b/lib/src/messages/markdown.dart
@@ -8,6 +8,10 @@ class MarkdownMessage extends Message {
 
   MarkdownMessage(this.body);
 
+  factory MarkdownMessage.fromMap(Map data) {
+    return new MarkdownMessage(data['body']);
+  }
+
   void render() {
     // TODO: implement render
   }
@@ -17,7 +21,6 @@ class MarkdownMessage extends Message {
   void add(Message m) => _children.add(m);
   bool remove(Message m) => _children.remove(m);
 
-  // TODO: Marshal children
   @override
   Map marshal() => {'type': 'markdown', 'body': body};
 }

--- a/lib/src/messages/markdown.dart
+++ b/lib/src/messages/markdown.dart
@@ -17,6 +17,7 @@ class MarkdownMessage extends Message {
   void add(Message m) => _children.add(m);
   bool remove(Message m) => _children.remove(m);
 
+  // TODO: Marshal children
   @override
   Map marshal() => {'type': 'markdown', 'body': body};
 }

--- a/lib/src/messages/markdown.dart
+++ b/lib/src/messages/markdown.dart
@@ -6,6 +6,8 @@ class MarkdownMessage extends Message {
   final List<Message> _children = new List<Message>();
   String body;
 
+  MarkdownMessage(this.body);
+
   void render() {
     // TODO: implement render
   }
@@ -14,4 +16,7 @@ class MarkdownMessage extends Message {
 
   void add(Message m) => _children.add(m);
   bool remove(Message m) => _children.remove(m);
+
+  @override
+  Map marshal() => {'type': 'markdown', 'body': body};
 }

--- a/lib/src/messages/message.dart
+++ b/lib/src/messages/message.dart
@@ -1,4 +1,4 @@
-library client.src.client.messages.message;
+library client.src.messages.message;
 
 abstract class Message {
   void render();

--- a/lib/src/messages/message.dart
+++ b/lib/src/messages/message.dart
@@ -1,5 +1,29 @@
 library client.src.messages.message;
 
+import 'package:client/src/messages/markdown.dart';
+
 abstract class Message {
+  Message();
+
+  /// The unmarshal factory function is used to instantiate messages based on
+  /// the type encoded in the marshaled format.
+  factory Message.unmarshal(Map payload) {
+    if (payload['type'] == null) {
+      throw new ArgumentError.notNull('data payload type');
+    }
+
+    // TODO: switch to enums for profit and value
+    switch (payload['type']) {
+      case 'markdown':
+        return new MarkdownMessage(payload['body']);
+      default:
+        print('Recieved unknown message type: ${payload['type']}');
+    }
+  }
+
+  // TODO: Write what a subclass of a message must do upon a render
   void render();
+
+  // TODO: Write what a sublcass of a message must do upon marshal
+  Map marshal();
 }

--- a/lib/src/messages/message.dart
+++ b/lib/src/messages/message.dart
@@ -13,6 +13,7 @@ abstract class Message {
     }
 
     // TODO: switch to enums for profit and value
+    // TODO: add other message types
     switch (payload['type']) {
       case 'markdown':
         return new MarkdownMessage(payload['body']);

--- a/lib/src/messages/message.dart
+++ b/lib/src/messages/message.dart
@@ -16,8 +16,9 @@ abstract class Message {
     // TODO: add other message types
     switch (payload['type']) {
       case 'markdown':
-        return new MarkdownMessage(payload['body']);
+        return new MarkdownMessage.fromMap(payload);
       default:
+        // TODO: Define some default type of message
         print('Recieved unknown message type: ${payload['type']}');
     }
   }

--- a/lib/src/transport_client.dart
+++ b/lib/src/transport_client.dart
@@ -1,5 +1,7 @@
-import 'package:client/src/client/channel.dart';
-import 'package:client/src/client/messages/message.dart';
+library client.src.transport_client;
+
+import 'package:client/src/channel.dart';
+import 'package:client/src/messages/message.dart';
 
 abstract class TransportClient {
   List<Channel> _channels = new List();

--- a/lib/src/transports/loopback_transport_client.dart
+++ b/lib/src/transports/loopback_transport_client.dart
@@ -1,0 +1,5 @@
+part of client.src.transports.transport_client;
+
+class LoopbackTransportClient extends TransportClient {
+  void send(Channel c, Message m) => notifySubscribers(c, m);
+}

--- a/lib/src/transports/loopback_transport_client.dart
+++ b/lib/src/transports/loopback_transport_client.dart
@@ -1,5 +1,34 @@
 part of client.src.transports.transport_client;
 
+/// Provides a mock IO that immediately receives
+class _Loopback {
+  StreamController<_LoopbackContext> _loopStream = new StreamController();
+
+  void submit(Channel c, Message m) =>
+      _loopStream.add(new _LoopbackContext(c, m));
+
+  Stream<_LoopbackContext> get incoming => _loopStream.stream;
+}
+
+/// A loopback data model used to collect messages and data into a immutable
+/// type.
+class _LoopbackContext {
+  final Channel channel;
+  final Message message;
+
+  _LoopbackContext(this.channel, this.message);
+}
+
+/// Provides a short circuit transport that immediately receives any sent
+/// messages.
 class LoopbackTransportClient extends TransportClient {
-  void send(Channel c, Message m) => notifySubscribers(c, m);
+  final _Loopback _loopback = new _Loopback();
+
+  LoopbackTransportClient() {
+    _loopback.incoming.listen(
+        (context) => notifySubscribers(context.channel, context.message));
+  }
+
+  /// Sends the given message across the loopback client for a given channel.
+  Future send(Channel c, Message m) async => _loopback.submit(c, m);
 }

--- a/lib/src/transports/transport_client.dart
+++ b/lib/src/transports/transport_client.dart
@@ -1,7 +1,10 @@
 library client.src.transports.transport_client;
 
+
 import 'package:client/src/channel.dart';
 import 'package:client/src/messages/message.dart';
+
+part 'loopback_transport_client.dart';
 
 abstract class TransportClient {
   List<Channel> _channels = new List();
@@ -23,6 +26,3 @@ abstract class TransportClient {
   }
 }
 
-class LoopbackTransportClient extends TransportClient {
-  void send(Channel c, Message m) => notifySubscribers(c, m);
-}

--- a/lib/src/transports/transport_client.dart
+++ b/lib/src/transports/transport_client.dart
@@ -1,14 +1,11 @@
 library client.src.transports.transport_client;
 
 import 'dart:async';
-import 'dart:html';
-import 'dart:convert';
 
 import 'package:client/src/channel.dart';
 import 'package:client/src/messages/message.dart';
 
 part 'loopback_transport_client.dart';
-part 'websocket_client.dart';
 
 abstract class TransportClient {
   List<Channel> _channels = new List();

--- a/lib/src/transports/transport_client.dart
+++ b/lib/src/transports/transport_client.dart
@@ -1,11 +1,14 @@
 library client.src.transports.transport_client;
 
 import 'dart:async';
+import 'dart:html';
+import 'dart:convert';
 
 import 'package:client/src/channel.dart';
 import 'package:client/src/messages/message.dart';
 
 part 'loopback_transport_client.dart';
+part 'websocket_client.dart';
 
 abstract class TransportClient {
   List<Channel> _channels = new List();

--- a/lib/src/transports/transport_client.dart
+++ b/lib/src/transports/transport_client.dart
@@ -1,5 +1,6 @@
 library client.src.transports.transport_client;
 
+import 'dart:async';
 
 import 'package:client/src/channel.dart';
 import 'package:client/src/messages/message.dart';
@@ -25,4 +26,3 @@ abstract class TransportClient {
         .forEach((Channel c) => c.receive(m));
   }
 }
-

--- a/lib/src/transports/transport_client.dart
+++ b/lib/src/transports/transport_client.dart
@@ -1,4 +1,4 @@
-library client.src.transport_client;
+library client.src.transports.transport_client;
 
 import 'package:client/src/channel.dart';
 import 'package:client/src/messages/message.dart';

--- a/lib/src/transports/websocket_client.dart
+++ b/lib/src/transports/websocket_client.dart
@@ -1,0 +1,49 @@
+part of client.src.transports.transport_client;
+
+class _WebSocketTransportContext {
+  final Channel channel;
+  final Message message;
+
+  _WebSocketTransportContext(this.channel, this.message);
+
+  factory _WebSocketTransportContext.fromJson(
+      Iterable<Channel> channels, String json) {
+    var map = JSON.decode(json);
+
+    var channel = channels.firstWhere((c) => c.title == map['channel'],
+        orElse: () => new GroupChannel(map['channel']));
+
+    return new _WebSocketTransportContext(
+        channel, new Message.unmarshal(map['data']));
+  }
+
+  String toJson() {
+    var map = new Map();
+
+    map['channel'] = channel.title;
+    map['data'] = message.marshal();
+
+    return JSON.encode(map);
+  }
+}
+
+class WebSocketTransportClient extends TransportClient {
+  WebSocket _webSocket;
+
+  WebSocketTransportClient(WebSocket ws) {
+    _webSocket = ws;
+    _webSocket.onMessage.listen(_handleMessage);
+  }
+
+  void send(Channel c, Message m) {
+    var context = new _WebSocketTransportContext(c, m);
+    _webSocket.send(context.toJson());
+  }
+
+  void _handleMessage(MessageEvent e) {
+    var context =
+        new _WebSocketTransportContext.fromJson(subscriptions, e.data);
+
+    notifySubscribers(context.channel, context.message);
+  }
+}

--- a/lib/src/transports/websocket_client.dart
+++ b/lib/src/transports/websocket_client.dart
@@ -1,4 +1,11 @@
-part of client.src.transports.transport_client;
+library client.src.transports.websocket_client;
+
+import 'dart:html';
+import 'dart:convert';
+
+import 'package:client/src/channel.dart';
+import 'package:client/src/messages/message.dart';
+import 'package:client/src/transports/transport_client.dart';
 
 class _WebSocketTransportContext {
   final Channel channel;

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -1,6 +1,8 @@
+library test.channel_test;
+
 import 'package:test/test.dart';
 
-import 'package:client/src/client/channel.dart';
+import 'package:client/src/channel.dart';
 import 'utils/mocks.dart';
 
 void main() {

--- a/test/messages/markdown_test.dart
+++ b/test/messages/markdown_test.dart
@@ -1,0 +1,16 @@
+library test.messages.markdown_test;
+import 'package:test/test.dart';
+import 'package:client/src/messages/markdown.dart';
+
+void main() {
+  group('MarkdownMessage', () {
+    test('marshal should build json', () {
+      const messageText = 'test body';
+      var message = new MarkdownMessage(messageText);
+      var map = message.marshal();
+
+      expect(map['type'], equals(('markdown')));
+      expect(map['body'], equals(messageText));
+    });
+  });
+}

--- a/test/messages/markdown_test.dart
+++ b/test/messages/markdown_test.dart
@@ -4,13 +4,18 @@ import 'package:client/src/messages/markdown.dart';
 
 void main() {
   group('MarkdownMessage', () {
-    test('marshal should build json', () {
-      const messageText = 'test body';
+    const messageText = 'test body';
+    test('marshal should build a valid json string', () {
       var message = new MarkdownMessage(messageText);
       var map = message.marshal();
 
       expect(map['type'], equals(('markdown')));
       expect(map['body'], equals(messageText));
+    });
+
+    test('factory should return expected values from map', () {
+      var message = new MarkdownMessage.fromMap({'body': messageText});
+      expect(message.body, equals(messageText));
     });
   });
 }

--- a/test/messages/message_test.dart
+++ b/test/messages/message_test.dart
@@ -1,0 +1,21 @@
+library test.messages.message_test;
+import 'package:test/test.dart';
+import 'package:client/src/messages/message.dart';
+import 'package:client/src/messages/markdown.dart';
+
+void main() {
+  group('Message', () {
+    group('factory function', () {
+      test('should throw ArgumentError if type is missing from map', () {
+        expect(() => new Message.unmarshal({}), throwsArgumentError);
+      });
+
+      test('should return MarkdownMessage type', () {
+        var data = {'type': 'markdown'};
+        var message = new Message.unmarshal(data);
+
+        expect(message, new isInstanceOf<MarkdownMessage>());
+      });
+    });
+  });
+}

--- a/test/transport_client_test.dart
+++ b/test/transport_client_test.dart
@@ -1,7 +1,9 @@
+library test.transport_client_test;
+
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
-import 'package:client/src/client/transport_client.dart';
+import 'package:client/src/transport_client.dart';
 
 import 'utils/mocks.dart';
 

--- a/test/transport_client_test.dart
+++ b/test/transport_client_test.dart
@@ -3,7 +3,7 @@ library test.transport_client_test;
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
-import 'package:client/src/transport_client.dart';
+import 'package:client/src/transports/transport_client.dart';
 
 import 'utils/mocks.dart';
 

--- a/test/transports/transport_client_test.dart
+++ b/test/transports/transport_client_test.dart
@@ -1,11 +1,11 @@
-library test.transport_client_test;
+library test.transports.transport_client_test;
 
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import 'package:client/src/transports/transport_client.dart';
 
-import 'utils/mocks.dart';
+import '../utils/mocks.dart';
 
 void main() {
   group('TransportClient', () {

--- a/test/utils/mocks.dart
+++ b/test/utils/mocks.dart
@@ -2,8 +2,8 @@ library client.test.utils.mocks;
 
 import 'package:mockito/mockito.dart';
 
-import 'package:client/src/client/channel.dart';
-import 'package:client/src/client/messages/message.dart';
+import 'package:client/src/channel.dart';
+import 'package:client/src/messages/message.dart';
 
 class MockChannel extends Mock implements Channel {
   noSuchMethod(i) => super.noSuchMethod(i);


### PR DESCRIPTION
I pulled the WebSocket proof of concept out of the Angular Spike(#9) and extended it with message type marshalling. This allows each message type to define how to marshall the message data/state as JSON to be sent over a transport. I am actively working to make this process more reflective and get serialiazation for free and the current implementation will allow this to persued at a future date. 

In addition this PR includes a refactorization of the project namespace that gets rid of a redundant client directory.

## Tests
* Added message factory tests
* Added marshalling tests for MarkdownMessages

## Reference
- #13 Add Message Serialization
