### PR TITLE
Apply Dart Formatting

### DIFF
--- a/test/messages/markdown_test.dart
+++ b/test/messages/markdown_test.dart
@@ -1,4 +1,5 @@
 library test.messages.markdown_test;
+
 import 'package:test/test.dart';
 import 'package:client/src/messages/markdown.dart';
 

--- a/test/messages/message_test.dart
+++ b/test/messages/message_test.dart
@@ -1,4 +1,5 @@
 library test.messages.message_test;
+
 import 'package:test/test.dart';
 import 'package:client/src/messages/message.dart';
 import 'package:client/src/messages/markdown.dart';


### PR DESCRIPTION
Not all of the codebase has the dart style applied. This is corrected by running
the dart style tool `dartfmt` on the repository.

Executed `dartfmt -w lib web test` and now the code is dartfmted.