### PR TITLE
Code Coverage; Resolves #25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 language: dart
 with_content_shell: true
+script: ./tool/travis.sh

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # client
-A web based Instant Message client.
+[![Build Status][build_status_img]][build_status_url] [![Coverage Status][cover_status_img]][cover_status_url]
+
+> A web based Instant Message client.
+
+[build_status_img]: https://travis-ci.org/uni-im/client.svg?branch=master
+[build_status_url]: https://travis-ci.org/uni-im/client
+[cover_status_img]: https://coveralls.io/repos/uni-im/client/badge.svg?branch=master&service=github
+[cover_status_url]: https://coveralls.io/github/uni-im/client?branch=master

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -1,0 +1,13 @@
+import 'package:test/test.dart';
+
+import 'messages/markdown_test.dart' as markdown_tests;
+import 'messages/message_test.dart' as message_tests;
+import 'transports/transport_client_test.dart' as transport_client_tests;
+import 'channel_test.dart' as channel_tests;
+
+void main() {
+  group('', channel_tests.main);
+  group('', markdown_tests.main);
+  group('', message_tests.main);
+  group('', transport_client_tests.main);
+}

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Jump ship on failure
+set -e
+
+# Fail if not dartfmt'd
+dartfmt -n lib test
+
+# Fail if analyzer warns
+dartanalyzer lib/client.dart test/all_tests.dart
+
+# Run tests 
+pub run test -r expanded -p vm 
+
+if [ "$COVERALLS_TOKEN" ]; then
+    # Run coverage tool if coveralls token is available
+    pub global activate dart_coveralls
+    pub global run dart_coveralls report \
+        --retry 2 \
+        --exclude-test-files \
+        test/all_tests.dart
+fi


### PR DESCRIPTION
We can use the dart_coveralls package to generate code coverage reports on pull requests. This coverage is reported to [coveralls.io](https://coveralls.io/github/uni-im/client) for reporting and coverage monitoring.