### PR TITLE
Add agency awareness; Closes #36

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -1,1 +1,5 @@
+export 'package:client/src/channel.dart';
+export "package:client/src/agent.dart";
+export "package:client/src/messages/message.dart";
+export 'package:client/src/messages/presenter.dart';
 export "package:client/src/transports/transport_client.dart";

--- a/lib/src/messages/control.dart
+++ b/lib/src/messages/control.dart
@@ -1,0 +1,15 @@
+library client.src.messages.client;
+
+import 'package:client/src/messages/message.dart';
+
+class ControlMessage extends Message {
+  String body;
+  final bool isControl = true;
+
+  ControlMessage(this.body);
+
+  dynamic render() => presenter.present();
+
+  @override
+  Map marshal() => {};
+}

--- a/lib/src/messages/message.dart
+++ b/lib/src/messages/message.dart
@@ -3,6 +3,7 @@ library client.src.messages.message;
 import 'package:client/src/agent.dart';
 import 'package:client/src/messages/markdown.dart';
 import 'package:client/src/messages/presenter.dart';
+import 'package:client/src/messages/control.dart';
 
 class MessageFactory {
   PresenterFactory presenterFactory;
@@ -31,11 +32,19 @@ class MessageFactory {
 
     return message;
   }
+
+  ControlMessage controlMessage(String messageText) {
+    var message = new ControlMessage(messageText);
+    message.presenter = presenterFactory.getPresenter(message);
+
+    return message;
+  }
 }
 
 abstract class Message {
   Agent author;
   Presenter presenter;
+  final bool isControl = false;
 
   // TODO: Write what a subclass of a message must do upon a render
   void render();

--- a/lib/src/transports/loopback_transport_client.dart
+++ b/lib/src/transports/loopback_transport_client.dart
@@ -24,7 +24,8 @@ class _LoopbackContext {
 class LoopbackTransportClient extends TransportClient {
   final _Loopback _loopback = new _Loopback();
 
-  LoopbackTransportClient(PresenterFactory pFactory) : super(pFactory) {
+  LoopbackTransportClient(Agent agent, PresenterFactory pFactory)
+      : super(agent, pFactory) {
     _loopback.incoming.listen(
         (context) => notifySubscribers(context.channel, context.message));
   }

--- a/lib/src/transports/transport_atoms.dart
+++ b/lib/src/transports/transport_atoms.dart
@@ -1,0 +1,1 @@
+part of client.src.transports.transport_client;

--- a/lib/src/transports/transport_atoms.dart
+++ b/lib/src/transports/transport_atoms.dart
@@ -1,1 +1,51 @@
 part of client.src.transports.transport_client;
+
+enum AtomType { message, control }
+
+AtomType typeFromString(String type) =>
+    AtomType.values.firstWhere((v) => v.toString() == type, orElse: () => null);
+
+abstract class TransportAtom {
+  final AtomType type;
+
+  TransportAtom(this.type);
+
+  String marshal({Map data}) {
+    return JSON.encode({'type': type.toString(), 'payload': data});
+  }
+}
+
+class MessageAtom extends TransportAtom {
+  final Message message;
+  final Channel channel;
+  MessageAtom(this.message, this.channel) : super(AtomType.message);
+
+  String marshal({Map data}) {
+    return super.marshal(
+        data: {'message': message.marshal(), 'channel': channel.title});
+  }
+}
+
+class TransportAtomFactory {
+  MessageFactory messageFactory;
+  Iterable<Channel> channels;
+
+  TransportAtomFactory(this.messageFactory, this.channels);
+
+  TransportAtom fromJson(String json) {
+    var blob = JSON.decode(json);
+    var type = typeFromString(blob['type']);
+
+    switch (type) {
+      case AtomType.message:
+        var message = messageFactory.fromJson(blob['data']['message']);
+        var channel = channels.firstWhere(
+            (c) => c.title == blob['data']['channel'],
+            orElse: () => new GroupChannel(blob['data']['channel']));
+
+        return new MessageAtom(message, channel);
+      default:
+        throw new ArgumentError.value('$type');
+    }
+  }
+}

--- a/lib/src/transports/transport_atoms.dart
+++ b/lib/src/transports/transport_atoms.dart
@@ -3,7 +3,8 @@ part of client.src.transports.transport_client;
 enum AtomType { message, control }
 
 AtomType atomTypeFromString(String type) =>
-    AtomType.values.firstWhere((v) => v.toString() == type, orElse: () => null);
+    AtomType.values.firstWhere((v) => v.toString() == type,
+        orElse: () => throw new ArgumentError.value(type));
 
 abstract class TransportAtom {
   final AtomType type;
@@ -27,8 +28,9 @@ class MessageAtom extends TransportAtom {
 }
 
 enum ControlType { agent }
-ControlType controlTypeFromString(String type) => ControlType.values
-    .firstWhere((v) => v.toString() == type, orElse: () => null);
+ControlType controlTypeFromString(String type) =>
+    ControlType.values.firstWhere((v) => v.toString() == type,
+        orElse: () => throw new ArgumentError.value(type));
 
 class ControlAtom extends TransportAtom {
   final ControlType control;
@@ -42,8 +44,9 @@ class ControlAtom extends TransportAtom {
 
 enum AgentCommand { joined, left }
 
-AgentCommand agentCommandFromString(String type) => AgentCommand.values
-    .firstWhere((v) => v.toString() == type, orElse: () => null);
+AgentCommand agentCommandFromString(String type) =>
+    AgentCommand.values.firstWhere((v) => v.toString() == type,
+        orElse: () => throw new ArgumentError.value(type));
 
 class AgentControlAtom extends ControlAtom {
   final AgentCommand command;

--- a/lib/src/transports/transport_atoms.dart
+++ b/lib/src/transports/transport_atoms.dart
@@ -25,6 +25,10 @@ class MessageAtom extends TransportAtom {
     return super.marshal(
         payload: {'message': message.marshal(), 'channel': channel.title});
   }
+
+  String toString() {
+    return "${message.author.name} sent a message on ${channel.title}";
+  }
 }
 
 enum ControlType { agent }
@@ -61,6 +65,10 @@ class AgentControlAtom extends ControlAtom {
       'agent': agent.name,
       'channel': channel?.title
     });
+  }
+
+  String toString() {
+    return "${agent.name} $command ${channel.title}";
   }
 }
 

--- a/lib/src/transports/transport_client.dart
+++ b/lib/src/transports/transport_client.dart
@@ -6,17 +6,19 @@ import 'dart:convert';
 import 'package:client/src/channel.dart';
 import 'package:client/src/messages/message.dart';
 import 'package:client/src/messages/presenter.dart';
+import 'package:client/src/agent.dart';
 
 part 'loopback_transport_client.dart';
 part 'transport_atoms.dart';
 
 abstract class TransportClient {
+  Agent agent;
   List<Channel> _channels = new List();
   Set<Channel> _subscriptions = new Set<Channel>();
 
   MessageFactory messageFactory;
 
-  TransportClient(PresenterFactory pFactory) {
+  TransportClient(this.agent, PresenterFactory pFactory) {
     messageFactory = new MessageFactory(pFactory);
   }
 

--- a/lib/src/transports/transport_client.dart
+++ b/lib/src/transports/transport_client.dart
@@ -7,6 +7,7 @@ import 'package:client/src/messages/message.dart';
 import 'package:client/src/messages/presenter.dart';
 
 part 'loopback_transport_client.dart';
+part 'transport_atoms.dart';
 
 abstract class TransportClient {
   List<Channel> _channels = new List();

--- a/lib/src/transports/transport_client.dart
+++ b/lib/src/transports/transport_client.dart
@@ -1,6 +1,7 @@
 library client.src.transports.transport_client;
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:client/src/channel.dart';
 import 'package:client/src/messages/message.dart';

--- a/lib/src/transports/websocket_client.dart
+++ b/lib/src/transports/websocket_client.dart
@@ -1,58 +1,30 @@
 library client.src.transports.websocket_client;
 
 import 'dart:html';
-import 'dart:convert';
 
 import 'package:client/src/channel.dart';
 import 'package:client/src/messages/message.dart';
 import 'package:client/src/transports/transport_client.dart';
 import 'package:client/src/messages/presenter.dart';
 
-class _WebSocketTransportContext {
-  final Channel channel;
-  final Map message;
-
-  _WebSocketTransportContext(this.channel, this.message);
-
-  factory _WebSocketTransportContext.fromJson(
-      Iterable<Channel> channels, String json) {
-    var map = JSON.decode(json);
-
-    var channel = channels.firstWhere((c) => c.title == map['channel'],
-        orElse: () => new GroupChannel(map['channel']));
-
-    return new _WebSocketTransportContext(channel, map['data']);
-  }
-
-  String toJson() {
-    var map = new Map();
-
-    map['channel'] = channel.title;
-    map['data'] = message;
-
-    return JSON.encode(map);
-  }
-}
-
 class WebSocketTransportClient extends TransportClient {
   WebSocket _webSocket;
+  TransportAtomFactory _atomFactory;
 
   WebSocketTransportClient(WebSocket ws, PresenterFactory pFactory)
       : super(pFactory) {
     _webSocket = ws;
     _webSocket.onMessage.listen(_handleMessage);
+    _atomFactory = new TransportAtomFactory(messageFactory, subscriptions);
   }
 
   void send(Channel c, Message m) {
-    var context = new _WebSocketTransportContext(c, m.marshal());
-    _webSocket.send(context.toJson());
+    var atom = new MessageAtom(m, c);
+    _webSocket.send(atom.marshal());
   }
 
   void _handleMessage(MessageEvent e) {
-    var context =
-        new _WebSocketTransportContext.fromJson(subscriptions, e.data);
-    var message = messageFactory.fromJson(context.message);
-
-    notifySubscribers(context.channel, message);
+    var atom = _atomFactory.fromJson(e.data);
+    notifySubscribers(atom.channel, atom.message);
   }
 }

--- a/lib/src/transports/websocket_client.dart
+++ b/lib/src/transports/websocket_client.dart
@@ -2,20 +2,43 @@ library client.src.transports.websocket_client;
 
 import 'dart:html';
 
+import 'package:client/src/agent.dart';
 import 'package:client/src/channel.dart';
 import 'package:client/src/messages/message.dart';
-import 'package:client/src/transports/transport_client.dart';
 import 'package:client/src/messages/presenter.dart';
+import 'package:client/src/transports/transport_client.dart';
 
 class WebSocketTransportClient extends TransportClient {
   WebSocket _webSocket;
   TransportAtomFactory _atomFactory;
 
-  WebSocketTransportClient(WebSocket ws, PresenterFactory pFactory)
-      : super(pFactory) {
+  WebSocketTransportClient(WebSocket ws, Agent agent, PresenterFactory pFactory)
+      : super(agent, pFactory) {
     _webSocket = ws;
     _webSocket.onMessage.listen(_handleMessage);
     _atomFactory = new TransportAtomFactory(messageFactory, subscriptions);
+  }
+
+  @override
+  bool join(Channel c) {
+    if (super.join(c)) {
+      var atom = new AgentControlAtom(AgentCommand.joined, agent, channel: c);
+      _webSocket.send(atom.marshal());
+
+      return true;
+    }
+
+    return false;
+  }
+
+  @override
+  bool leave(Channel c) {
+    var left = super.leave(c);
+
+    _webSocket.send(
+        new AgentControlAtom(AgentCommand.left, agent, channel: c).marshal());
+
+    return left;
   }
 
   void send(Channel c, Message m) {
@@ -25,6 +48,15 @@ class WebSocketTransportClient extends TransportClient {
 
   void _handleMessage(MessageEvent e) {
     var atom = _atomFactory.fromJson(e.data);
-    notifySubscribers(atom.channel, atom.message);
+
+    if (atom is MessageAtom) {
+      notifySubscribers(atom.channel, atom.message);
+    } else if (atom is AgentControlAtom) {
+      var verb = atom.command == AgentCommand.joined ? 'joined' : 'left';
+      notifySubscribers(
+          atom.channel,
+          messageFactory
+              .controlMessage('${atom.agent.name} $verb the channel'));
+    }
   }
 }

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -1,17 +1,21 @@
 import 'package:test/test.dart';
 
 import 'agent_test.dart' as agent_tests;
+import 'channel_test.dart' as channel_tests;
+import 'messages/control_message.dart' as control_tests;
 import 'messages/markdown_test.dart' as markdown_tests;
 import 'messages/message_test.dart' as message_tests;
 import 'transports/loopback_client_test.dart' as loopback_transport_tests;
+import 'transports/transport_atoms_test.dart' as transport_atoms_tests;
 import 'transports/transport_client_test.dart' as transport_client_tests;
-import 'channel_test.dart' as channel_tests;
 
 void main() {
   group('', agent_tests.main);
   group('', channel_tests.main);
+  group('', control_tests.main);
   group('', markdown_tests.main);
   group('', message_tests.main);
   group('', loopback_transport_tests.main);
+  group('', transport_atoms_tests.main);
   group('', transport_client_tests.main);
 }

--- a/test/messages/control_message.dart
+++ b/test/messages/control_message.dart
@@ -3,7 +3,6 @@ library test.messages.control_message_test;
 import 'package:test/test.dart';
 import 'package:mockito/mockito.dart';
 
-import 'package:client/src/messages/control.dart';
 import 'package:client/src/messages/message.dart';
 import '../utils/mocks.dart';
 import 'package:client/src/messages/presenter.dart';

--- a/test/messages/control_message.dart
+++ b/test/messages/control_message.dart
@@ -1,0 +1,31 @@
+library test.messages.control_message_test;
+
+import 'package:test/test.dart';
+import 'package:mockito/mockito.dart';
+
+import 'package:client/src/messages/control.dart';
+import 'package:client/src/messages/message.dart';
+import '../utils/mocks.dart';
+import 'package:client/src/messages/presenter.dart';
+
+void main() {
+  group('ControlMessage', () {
+    MessageFactory messageFactory;
+    Presenter presenter;
+
+    setUp(() {
+      presenter = new MockPresenter();
+      var mockPresenterFactory = new MockPresenterFactory();
+
+      when(mockPresenterFactory.getPresenter(any)).thenReturn(presenter);
+      messageFactory = new MessageFactory(mockPresenterFactory);
+    });
+
+    test('should marshal to empty map', () {
+      var message = messageFactory.controlMessage('test message');
+      expect(message.marshal(), equals({}));
+      expect(message.render(), equals('test message'));
+      verify(presenter.present()).called(1);
+    });
+  });
+}

--- a/test/messages/message_test.dart
+++ b/test/messages/message_test.dart
@@ -39,6 +39,11 @@ void main() {
           expect(message.presenter, same(presenter));
         });
 
+        test('should return control message', () {
+          var message = messageFactory.controlMessage('test message');
+          expect(message.presenter, same(presenter));
+        });
+
         test('should call presenter present call on render', () async {
           var message = messageFactory.fromJson(messageData);
           await message.render();

--- a/test/transports/loopback_client_test.dart
+++ b/test/transports/loopback_client_test.dart
@@ -10,7 +10,8 @@ import '../utils/mocks.dart';
 main() {
   group('LoopbackTransportClient', () {
     test('should notify a channel on submission', () async {
-      var client = new LoopbackTransportClient(new MockPresenterFactory());
+      var client = new LoopbackTransportClient(
+          new MockAgent(), new MockPresenterFactory());
       var channel = new MockChannel();
       var message = new MockMessage();
 

--- a/test/transports/transport_atoms_test.dart
+++ b/test/transports/transport_atoms_test.dart
@@ -1,0 +1,94 @@
+library test.transports.transport_atoms_test;
+
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import 'package:client/src/transports/transport_client.dart';
+
+import '../utils/mocks.dart';
+import 'package:client/src/messages/message.dart';
+import 'package:client/src/channel.dart';
+
+void main() {
+  group('String to type function', () {
+    group('atomTypeFromString', () {
+      test('should return correct type for stringified value', () {
+        AtomType.values.forEach((type) =>
+            expect(atomTypeFromString(type.toString()), equals(type)));
+      });
+
+      test('should throw argument exception if not a valid string', () {
+        expect(() => atomTypeFromString('badTypeString'), throwsArgumentError);
+      });
+    });
+    group('controlTypeFromString', () {
+      test('should return correct type for stringified value', () {
+        ControlType.values.forEach((type) =>
+            expect(controlTypeFromString(type.toString()), equals(type)));
+      });
+
+      test('should throw argument exception if not a valid string', () {
+        expect(
+            () => controlTypeFromString('badTypeString'), throwsArgumentError);
+      });
+    });
+    group('agentCommandFromString', () {
+      test('should return correct type for stringified value', () {
+        AgentCommand.values.forEach((type) =>
+            expect(agentCommandFromString(type.toString()), equals(type)));
+      });
+
+      test('should throw argument exception if not a valid string', () {
+        expect(
+            () => agentCommandFromString('badTypeString'), throwsArgumentError);
+      });
+    });
+  });
+
+  group('TransportAtomFactory', () {
+    TransportAtomFactory transportAtomFactory;
+    MessageFactory messageFactory = new MockMessageFactory();
+    Message message = new MockMessage();
+    Channel channel = new MockChannel();
+
+    setUp(() {
+      when(message.marshal()).thenReturn({'data': 'mock'});
+      when(channel.title).thenReturn('title');
+
+      transportAtomFactory = new TransportAtomFactory(messageFactory, []);
+    });
+
+    group('should return atom type of', () {
+      test('MessageAtom when passed json payload', () {
+        var messageAtom = new MessageAtom(message, channel);
+
+        MessageAtom parseAtom =
+            transportAtomFactory.fromJson(messageAtom.marshal());
+
+        verify(messageFactory.fromJson({'data': 'mock'}));
+        expect(parseAtom.channel.title, equals('title'));
+      });
+
+      group('ControlAtom when passed', () {
+        test('json payload', () {
+          var agent = new MockAgent();
+          when(agent.name).thenReturn('sisyphus');
+
+          var controlAtom = new AgentControlAtom(AgentCommand.joined, agent);
+
+          AgentControlAtom parsedAtom =
+              transportAtomFactory.fromJson(controlAtom.marshal());
+
+          expect(parsedAtom.agent.name, equals('sisyphus'));
+        });
+      });
+    });
+
+    test('should throw exception when parsing unkown type', () {
+      expect(
+          () => transportAtomFactory
+              .fromJson('{"type": "badType", "payload": "payload"}'),
+          throwsArgumentError);
+    });
+  });
+}

--- a/test/transports/transport_client_test.dart
+++ b/test/transports/transport_client_test.dart
@@ -13,7 +13,8 @@ void main() {
     MockChannel channel;
 
     setUp(() {
-      client = new LoopbackTransportClient(new MockPresenterFactory());
+      client = new LoopbackTransportClient(
+          new MockAgent(), new MockPresenterFactory());
       channel = new MockChannel();
     });
 

--- a/test/utils/mocks.dart
+++ b/test/utils/mocks.dart
@@ -19,6 +19,10 @@ class MockMessage extends Mock implements Message {
   noSuchMethod(i) => super.noSuchMethod(i);
 }
 
+class MockMessageFactory extends Mock implements MessageFactory {
+  noSuchMethod(i) => super.noSuchMethod(i);
+}
+
 class MockPresenter extends Mock implements Presenter {
   noSuchMethod(i) => super.noSuchMethod(i);
 }

--- a/test/utils/mocks.dart
+++ b/test/utils/mocks.dart
@@ -2,9 +2,14 @@ library client.test.utils.mocks;
 
 import 'package:mockito/mockito.dart';
 
+import 'package:client/src/agent.dart';
 import 'package:client/src/channel.dart';
 import 'package:client/src/messages/message.dart';
 import 'package:client/src/messages/presenter.dart';
+
+class MockAgent extends Mock implements Agent {
+  noSuchMethod(i) => super.noSuchMethod(i);
+}
 
 class MockChannel extends Mock implements Channel {
   noSuchMethod(i) => super.noSuchMethod(i);

--- a/web/index.html
+++ b/web/index.html
@@ -51,15 +51,16 @@
             <div class="col-xs-12 col-sm-12 col-md-12 messages">
                 <div ng-if="selectedChannel.messages.isEmpty"><em>There are no messages, be the first!</em></div>
                 <div ng-repeat="message in selectedChannel.messages" class="media">
-                    <div class="media-left media-top">
+                    <div ng-if="!message.isControl" class="media-left media-top">
                         <a href="#">
                             <img class="avatar media-object" src="http://api.adorable.io/avatars/64/{{message.author.name}}.png" alt="{{message.author.name}}'s avatar">
                         </a>
                     </div>
                     <div class="media-body">
-                        <h4 class="media-heading">{{message.author.name}}</h4>
+                        <h4 ng-if="!message.isControl" class="media-heading">{{message.author.name}}</h4>
                          <div class='message-container' ng-bind-html="message.render()"></div>
                     </div>
+                  </div>
                 </div>
                 <div class="row ">
                     <div class="col-xs-12 col-sm-12 col-md-12 message-input-area">

--- a/web/src/im_uni_client.dart
+++ b/web/src/im_uni_client.dart
@@ -48,7 +48,7 @@ class ImUniClient {
   String messageText;
 
   ImUniClient() {
-    WebSocket ws = new WebSocket('ws://localhost:8081');
+    WebSocket ws = new WebSocket('ws://magic-man.benjica.com:8081/v1/ws');
     SimplePresenterFactory pFactory = new SimplePresenterFactory();
     ws
       ..onOpen.first.then((_) =>

--- a/web/src/im_uni_client.dart
+++ b/web/src/im_uni_client.dart
@@ -56,16 +56,15 @@ class ImUniClient {
       ..onError.first.then(
           (_) => _init(new LoopbackTransportClient(currentAgent, pFactory)));
 
-    window.onUnload.listen((_) {
-      client.subscriptions.forEach(client.leave);
-    });
+    window.onUnload
+        .listen((_) => client.subscriptions.toList().forEach(client.leave));
   }
 
   void _init(TransportClient c) {
     client = c;
 
     // TODO: Implement channel persistence across server
-    ['foo', 'bar', 'biz'].map(client.createChannel)..forEach(client.join);
+    ['foo', 'bar', 'biz'].map(client.createChannel).forEach(client.join);
     selectedChannel = client.channels.first;
   }
 

--- a/web/src/im_uni_client.dart
+++ b/web/src/im_uni_client.dart
@@ -10,6 +10,7 @@ import 'package:client/src/messages/presenter.dart';
 import 'package:markdown/markdown.dart';
 import 'package:client/src/messages/message.dart';
 import 'package:angular/angular.dart';
+import 'package:client/src/messages/control.dart';
 
 class MarkdownPresenter extends Presenter {
   MarkdownMessage message;
@@ -21,9 +22,21 @@ class MarkdownPresenter extends Presenter {
   }
 }
 
+class ControlPresenter extends Presenter {
+  ControlMessage message;
+
+  ControlPresenter(this.message);
+
+  present() => '<em>${message.body}</em>';
+}
+
 class SimplePresenterFactory extends PresenterFactory {
   Presenter getPresenter(Message m) {
-    return new MarkdownPresenter(m);
+    if (m is MarkdownMessage) {
+      return new MarkdownPresenter(m);
+    } else {
+      return new ControlPresenter(m);
+    }
   }
 }
 
@@ -35,13 +48,17 @@ class ImUniClient {
   String messageText;
 
   ImUniClient() {
-    WebSocket ws = new WebSocket('ws://magic-man.benjica.com:8081');
+    WebSocket ws = new WebSocket('ws://localhost:8081');
     SimplePresenterFactory pFactory = new SimplePresenterFactory();
     ws
-      ..onOpen
-          .first
-          .then((_) => _init(new WebSocketTransportClient(ws, pFactory)))
-      ..onError.first.then((_) => _init(new LoopbackTransportClient(pFactory)));
+      ..onOpen.first.then((_) =>
+          _init(new WebSocketTransportClient(ws, currentAgent, pFactory)))
+      ..onError.first.then(
+          (_) => _init(new LoopbackTransportClient(currentAgent, pFactory)));
+
+    window.onUnload.listen((_) {
+      client.subscriptions.forEach(client.leave);
+    });
   }
 
   void _init(TransportClient c) {
@@ -57,7 +74,7 @@ class ImUniClient {
   }
 
   void sendMessage() {
-    MarkdownMessage m = new MessageFactory(null).createMessage(messageText);
+    MarkdownMessage m = client.messageFactory.createMessage(messageText);
     m.author = currentAgent;
     client.send(selectedChannel, m);
 


### PR DESCRIPTION
Refactored marshalling to use typed interfaces allowing for complicated
websocket communication that marshals and unmarshals through a common 
factory. This will allow the server to be more intelligent about messages
pass through it, ie cache only messages and pass control commands.

Added control messages to pass state changes that are not messages. This
is fundamental to operations such as agency in a channel or channel
changes.